### PR TITLE
feat(api): api router with prisma client

### DIFF
--- a/libs/clients.ts
+++ b/libs/clients.ts
@@ -1,10 +1,3 @@
 import { PrismaClient } from '@prisma/client';
 
-const client = new PrismaClient();
-
-client.user.create({
-  data: {
-    email: 'cheonaru@gmail.com',
-    name: 'clarko',
-  },
-});
+export default new PrismaClient();

--- a/pages/api/client-test.tsx
+++ b/pages/api/client-test.tsx
@@ -1,0 +1,13 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import client from '../../libs/clients';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  await client.user.create({
+    data: {
+      email: 'cheonaru@gmail.com',
+      name: 'clarko',
+    },
+  });
+
+  res.json({ ok: true, data: 'clarko' });
+}


### PR DESCRIPTION
## 커밋 내용 요약

- prisma 클라이언트를 활용하여 API 호출 시 신규 유저를 생성하는 예제

## 구현방법 및 변경사항

- api/~와 같은 경로명을 통해 서버 구현 없이도 API 라우팅이 가능
- prisma 클라이언트를 프론트엔드에서 호출 시 에러 발생 
  - prisma 클라이언트는 데이터베이스와 직결되기에 호출하면 안된다

## 질문사항

- prisma 클라이언트를 호출할 수 있는 위치가 pages/api 말고도 있을까?