### PR TITLE
feat(auth): userId와 일치하는 사용자 정보 수신, 로그인 사용자 DB 토큰 말소

### DIFF
--- a/libs/server/index.ts
+++ b/libs/server/index.ts
@@ -1,2 +1,3 @@
 export { default as client } from './client';
 export { default as withHandler } from './withHandler';
+export * from './withSession';

--- a/libs/server/withSession.ts
+++ b/libs/server/withSession.ts
@@ -1,0 +1,19 @@
+import { withIronSessionApiRoute } from 'iron-session/next';
+import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
+
+declare module 'iron-session' {
+  interface IronSessionData {
+    user?: {
+      id: number;
+    };
+  }
+}
+
+const cookieOption = {
+  cookieName: 'carrotsession',
+  password: process.env.COOKIE_PASSWORD!,
+};
+
+export function withApiSession(handlerFn: NextApiHandler<any>) {
+  return withIronSessionApiRoute(handlerFn, cookieOption);
+}

--- a/pages/api/users/confirm.tsx
+++ b/pages/api/users/confirm.tsx
@@ -12,18 +12,23 @@ declare module 'iron-session' {
 
 async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) {
   const { token } = req.body;
-  const tokenWithUser = await client.token.findUnique({
+  const foundToken = await client.token.findUnique({
     where: {
       payload: token,
     },
   });
 
-  if (!tokenWithUser) return res.status(404).end();
+  if (!foundToken) return res.status(404).end();
 
   req.session.user = {
-    id: tokenWithUser.userId,
+    id: foundToken.userId,
   };
   await req.session.save();
+  await client.token.deleteMany({
+    where: {
+      userId: foundToken.userId,
+    },
+  });
   res.json({ ok: true });
 }
 

--- a/pages/api/users/confirm.tsx
+++ b/pages/api/users/confirm.tsx
@@ -1,6 +1,5 @@
 import type { ResponseType } from '@customTypes/index';
-import { client, withHandler } from '@libs/server/index';
-import { withIronSessionApiRoute } from 'iron-session/next';
+import { client, withApiSession, withHandler } from '@libs/server/index';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 declare module 'iron-session' {
@@ -25,10 +24,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) 
     id: tokenWithUser.userId,
   };
   await req.session.save();
-  res.status(200).end();
+  res.json({ ok: true });
 }
 
-export default withIronSessionApiRoute(withHandler('POST', handler), {
-  cookieName: 'carrotsession',
-  password: 'sodkfo90whgodjwognwoeriroghtutq;sofufbsofjrgbaoasdi',
-});
+export default withApiSession(withHandler('POST', handler));

--- a/pages/api/users/me.tsx
+++ b/pages/api/users/me.tsx
@@ -12,23 +12,17 @@ declare module 'iron-session' {
 }
 
 async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) {
-  const { token } = req.body;
-  const tokenWithUser = await client.token.findUnique({
-    where: {
-      payload: token,
-    },
+  console.log(req.session.user);
+  const profile = await client.user.findUnique({
+    where: { id: req.session.user?.id },
   });
-
-  if (!tokenWithUser) return res.status(404).end();
-
-  req.session.user = {
-    id: tokenWithUser.userId,
-  };
-  await req.session.save();
-  res.status(200).end();
+  res.json({
+    ok: true,
+    profile,
+  });
 }
 
-export default withIronSessionApiRoute(withHandler('POST', handler), {
+export default withIronSessionApiRoute(withHandler('GET', handler), {
   cookieName: 'carrotsession',
   password: 'sodkfo90whgodjwognwoeriroghtutq;sofufbsofjrgbaoasdi',
 });

--- a/pages/api/users/me.tsx
+++ b/pages/api/users/me.tsx
@@ -1,18 +1,9 @@
 import type { ResponseType } from '@customTypes/index';
 import { client, withHandler } from '@libs/server/index';
-import { withIronSessionApiRoute } from 'iron-session/next';
+import { withApiSession } from '@libs/server/withSession';
 import { NextApiRequest, NextApiResponse } from 'next';
 
-declare module 'iron-session' {
-  interface IronSessionData {
-    user?: {
-      id: number;
-    };
-  }
-}
-
 async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) {
-  console.log(req.session.user);
   const profile = await client.user.findUnique({
     where: { id: req.session.user?.id },
   });
@@ -22,7 +13,4 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) 
   });
 }
 
-export default withIronSessionApiRoute(withHandler('GET', handler), {
-  cookieName: 'carrotsession',
-  password: 'sodkfo90whgodjwognwoeriroghtutq;sofufbsofjrgbaoasdi',
-});
+export default withApiSession(withHandler('GET', handler));

--- a/pages/enter.tsx
+++ b/pages/enter.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
-import { useForm } from 'react-hook-form';
 import { Button, Input } from '@components/index';
-import { useMutation, cls } from '@libs/client/index';
+import { cls, useMutation } from '@libs/client/index';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
 
 interface EnterForm {
   email?: string;
@@ -17,6 +18,7 @@ interface MutationResult {
 }
 
 export default function Enter() {
+  const router = useRouter();
   const [enter, { loading, data, error }] = useMutation<MutationResult>('/api/users/enter');
   const [confirmToken, { loading: tokenLoading, data: tokenData }] = useMutation<MutationResult>('/api/users/confirm');
   const { register, handleSubmit, reset } = useForm<EnterForm>();
@@ -37,11 +39,14 @@ export default function Enter() {
   };
   const onTokenValid = (validForm: TokenForm) => {
     if (tokenLoading) return;
-    console.log(validForm);
     confirmToken(validForm);
   };
 
-  console.log(data);
+  useEffect(() => {
+    if (tokenData?.ok) {
+      router.push('/');
+    }
+  }, [tokenData, router]);
 
   return (
     <div className="mt-16 px-4">


### PR DESCRIPTION
## 커밋 내용 요약

- 토큰과 일치하는 사용자 ID 탐색 후 있다면 세션에 저장
- 토큰과 일치하는 사용자 ID를 찾았다면 home("/")으로 이동

## 구현방법 및 변경사항

- iron-session을 통한 쿠키 암호화