### PR TITLE
feat(isLIked): 물품 상세페이지 좋아요 하트 표시

### DIFF
--- a/components/item.tsx
+++ b/components/item.tsx
@@ -11,7 +11,7 @@ interface ItemProps {
 export default function Item({ title, id, price, hearts, comments }: ItemProps) {
   return (
     <Link href={`/products/${id}`}>
-      <a className="flex px-4 pt-5 cursor-pointer justify-between">
+      <a className="flex px-4 py-8 cursor-pointer justify-between">
         <div className="flex space-x-4">
           <div className="w-20 h-20 bg-gray-400 rounded-md" />
           <div className="pt-2 flex flex-col">
@@ -37,7 +37,7 @@ export default function Item({ title, id, price, hearts, comments }: ItemProps) 
             </svg>
             <span>{hearts}</span>
           </div>
-          <div className="flex space-x-0.5 items-center text-sm  text-gray-600">
+          {/* <div className="flex space-x-0.5 items-center text-sm  text-gray-600">
             <svg
               className="w-4 h-4"
               fill="none"
@@ -53,7 +53,7 @@ export default function Item({ title, id, price, hearts, comments }: ItemProps) 
               ></path>
             </svg>
             <span>{comments}</span>
-          </div>
+          </div> */}
         </div>
       </a>
     </Link>

--- a/pages/api/products/[id]/index.ts
+++ b/pages/api/products/[id]/index.ts
@@ -5,7 +5,10 @@ import { NextApiRequest, NextApiResponse } from 'next';
 async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) {
   switch (req.method) {
     case 'GET':
-      const { id } = req.query;
+      const {
+        query: { id },
+        session: { user },
+      } = req;
       const product = await client.product.findUnique({
         where: {
           id: +id,
@@ -29,9 +32,19 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) 
           },
         },
       });
+      const isLiked = Boolean(
+        await client.fav.findFirst({
+          where: {
+            userId: user?.id,
+            productId: product?.id,
+          },
+          select: { id: true },
+        }),
+      );
       res.json({
         ok: true,
         product,
+        isLiked,
         relatedProducts,
       });
       break;

--- a/pages/api/products/index.ts
+++ b/pages/api/products/index.ts
@@ -5,7 +5,15 @@ import { NextApiRequest, NextApiResponse } from 'next';
 async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) {
   switch (req.method) {
     case 'GET':
-      const products = await client.product.findMany();
+      const products = await client.product.findMany({
+        include: {
+          _count: {
+            select: {
+              favs: true,
+            },
+          },
+        },
+      });
       res.json({
         ok: true,
         products,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,9 +4,13 @@ import { Product } from '.prisma/client';
 import type { NextPage } from 'next';
 import useSWR from 'swr';
 
+interface ProductWithCount extends Product {
+  _count: any;
+}
+
 interface ProductResponse {
   ok: boolean;
-  products: Product[];
+  products: ProductWithCount[];
 }
 
 const Home: NextPage = () => {
@@ -17,9 +21,16 @@ const Home: NextPage = () => {
 
   return (
     <Layout title="홈" hasTabBar>
-      <div className="flex flex-col space-y-5 py-10">
+      <div className="flex flex-col space-y-1 py-2 divide-y">
         {data?.products?.map((product) => (
-          <Item key={product.id} id={product.id} title={product.name} price={product.price} hearts={1} comments={1} />
+          <Item
+            key={product.id}
+            id={product.id}
+            title={product.name}
+            price={product.price}
+            hearts={product._count.favs}
+            comments={1}
+          />
         ))}
         <FloatingButton href={'/products/upload'}>
           <svg

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -1,5 +1,6 @@
 import { Product, User } from '.prisma/client';
 import { Button, Layout } from '@components/index';
+import { cls, useMutation } from '@libs/client';
 import type { NextPage } from 'next';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -13,31 +14,17 @@ interface ItemDetailResponse {
   ok: boolean;
   product: ProductWithUser;
   relatedProducts: Product[];
+  isLiked: boolean;
 }
 
 const ItemDetail: NextPage = () => {
   const date = new Date();
   const router = useRouter();
-  const { data: loading, error } = useSWR<ItemDetailResponse>(
-    router.query.id ? `/api/products/${router.query.id}` : null,
-  );
-  const data: ItemDetailResponse = loading || {
-    ok: false,
-    product: {
-      user: { id: 0, createdAt: date, name: '--', updatedAt: date, email: null, phone: null, avatar: null },
-      userId: 0,
-      id: 0,
-      name: '--',
-      price: 0,
-      description: '--',
-      imageUrl: '',
-      createdAt: date,
-      updatedAt: date,
-    },
-    relatedProducts: [],
+  const { data, error } = useSWR<ItemDetailResponse>(router.query.id ? `/api/products/${router.query.id}` : null);
+  const [toggleFav] = useMutation(`/api/products/${router.query.id}/fav`);
+  const onFavClick = () => {
+    toggleFav({});
   };
-
-  console.log(data);
 
   return (
     <Layout canGoBack>
@@ -59,22 +46,38 @@ const ItemDetail: NextPage = () => {
             <p className=" my-6 text-gray-700">{data?.product.description}</p>
             <div className="flex items-center justify-between space-x-2">
               <Button large text="Talk to seller" />
-              <button className="p-3 rounded-md flex items-center justify-center text-gray-400 hover:bg-gray-100 hover:text-gray-500">
-                <svg
-                  className="h-6 w-6 "
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
-                  />
-                </svg>
+              <button
+                onClick={onFavClick}
+                className={cls(
+                  'p-3 rounded-md flex items-center justify-center hover:bg-gray-100',
+                  data?.isLiked ? 'text-red-500  hover:text-red-600' : 'text-gray-400  hover:text-gray-500',
+                )}
+              >
+                {data?.isLiked ? (
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                    <path
+                      fillRule="evenodd"
+                      d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                ) : (
+                  <svg
+                    className="h-6 w-6 "
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
+                      d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+                    />
+                  </svg>
+                )}
               </button>
             </div>
           </div>

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -18,11 +18,12 @@ interface ItemDetailResponse {
 }
 
 const ItemDetail: NextPage = () => {
-  const date = new Date();
   const router = useRouter();
-  const { data, error } = useSWR<ItemDetailResponse>(router.query.id ? `/api/products/${router.query.id}` : null);
+  const { data, mutate } = useSWR<ItemDetailResponse>(router.query.id ? `/api/products/${router.query.id}` : null);
   const [toggleFav] = useMutation(`/api/products/${router.query.id}/fav`);
   const onFavClick = () => {
+    if (!data) return;
+    mutate({ ...data, isLiked: !data.isLiked }, false);
     toggleFav({});
   };
 
@@ -34,7 +35,7 @@ const ItemDetail: NextPage = () => {
           <div className="flex cursor-pointer py-3 border-t border-b items-center space-x-3">
             <div className="w-12 h-12 rounded-full bg-slate-300" />
             <div>
-              <p className="text-sm font-medium text-gray-700">{data?.product.user.name}</p>
+              <p className="text-sm font-medium text-gray-700">{data?.product?.user?.name}</p>
               <Link href={`/users/profiles/${data?.product.userId}`}>
                 <a className="text-xs font-medium text-gray-500">View profile &rarr;</a>
               </Link>
@@ -54,7 +55,7 @@ const ItemDetail: NextPage = () => {
                 )}
               >
                 {data?.isLiked ? (
-                  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" viewBox="0 0 20 20" fill="currentColor">
                     <path
                       fillRule="evenodd"
                       d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z"
@@ -85,7 +86,7 @@ const ItemDetail: NextPage = () => {
         <div>
           <h2 className="text-2xl font-bold text-gray-900">Similar items</h2>
           <div className=" mt-6 grid grid-cols-2 gap-4">
-            {data?.relatedProducts.map((relatedProduct) => (
+            {data?.relatedProducts?.map((relatedProduct) => (
               <Link href={`/products/${relatedProduct.id}`} key={relatedProduct.id}>
                 <a>
                   <div className="h-56 w-full mb-4 bg-slate-300" />


### PR DESCRIPTION
## 커밋 내용 요약

- 물품 정보 요청 시 좋아요 상태 확인
- home("/") 페이지 좋아요 숫자 표시

## 구현방법 및 변경사항

- product api에 isLiked 필드 추가
- optimistic ui update
  - api 결과가 긍정적(optimisitc)일 것이라는 가정
  - 캐시의 내용만 수정하고 revalidation과 api추가 요청을 제한
- bound mutation
    ```typescript
    const { data, mutate: boundMutate } = useSWR<ItemDetailResponse>(...);
    
    if (!data) return;
    boundMutate((prev: any) => prev && { ...prev, isLiked: !prev.isLiked }, false);
    ```