### PR TITLE
feat(edit profile): 마이캐럿 사용자 정보 변경

### DIFF
--- a/pages/api/users/me/index.ts
+++ b/pages/api/users/me/index.ts
@@ -3,18 +3,103 @@ import { client, withApiSession, withHandler } from '@libs/server/index';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) {
-  const profile = await client.user.findUnique({
-    where: { id: req.session.user?.id },
-  });
-  res.json({
-    ok: true,
-    profile,
-  });
+  switch (req.method) {
+    case 'GET':
+      const profile = await client.user.findUnique({
+        where: { id: req.session.user?.id },
+      });
+      return res.json({
+        ok: true,
+        profile,
+      });
+    case 'POST':
+      const {
+        body: { email, phone, name },
+        session: { user },
+      } = req;
+      const currentUser = await client.user.findUnique({
+        where: {
+          id: user?.id,
+        },
+        select: {
+          email: true,
+          phone: true,
+          name: true,
+        },
+      });
+      if (email && currentUser?.email !== email) {
+        const isExists = await client.user.findFirst({
+          where: {
+            email,
+          },
+          select: {
+            id: true,
+          },
+        });
+        if (isExists) {
+          return res.json({
+            ok: false,
+            error: 'Email already exists',
+          });
+        }
+        await client.user.update({
+          where: {
+            id: user?.id,
+          },
+          data: {
+            email,
+          },
+        });
+        return res.json({ ok: true });
+      }
+      if (phone && currentUser?.phone !== phone) {
+        const isExists = await client.user.findFirst({
+          where: {
+            phone,
+          },
+          select: {
+            id: true,
+          },
+        });
+        if (isExists) {
+          return res.json({
+            ok: false,
+            error: 'Phone number in use',
+          });
+        }
+        await client.user.update({
+          where: {
+            id: user?.id,
+          },
+          data: {
+            phone,
+          },
+        });
+        return res.json({ ok: true, message: 'not changed' });
+      }
+      if (name && currentUser?.name !== name) {
+        await client.user.update({
+          where: {
+            id: user?.id,
+          },
+          data: {
+            name,
+          },
+        });
+        return res.json({ ok: true, message: 'not changed' });
+      }
+      return res.json({ ok: true });
+    default:
+      return res.json({
+        ok: false,
+        error: 'Method not allowed',
+      });
+  }
 }
 
 export default withApiSession(
   withHandler({
-    methods: ['GET'],
+    methods: ['GET', 'POST'],
     handler,
   }),
 );


### PR DESCRIPTION
## 커밋 내용 요약

- 마이캐럿 페이지 사용자 정보변경
  - 사용하려는 이메일과 전화번호가 존재할 경우 거부
  - name(닉네임)은 중복 가능하도록 설정

## 코드 변경 이유

- 사용자 정보 수정 시 사용자 정보 요청과 동일한 url 사용

## 구현방법 및 변경사항

- API 허용 메서드 종류 추가
  - GET => GET, POST