### PR TITLE
feat(upload image): upload image with cloudinary, not cloudflare

### DIFF
--- a/components/item.tsx
+++ b/components/item.tsx
@@ -5,15 +5,23 @@ interface ItemProps {
   id: number;
   price: number;
   hearts: number;
+  imageUrl: string;
   comments: number;
 }
 
-export default function Item({ title, id, price, hearts, comments }: ItemProps) {
+export default function Item({ title, id, price, hearts, imageUrl, comments }: ItemProps) {
   return (
     <Link href={`/products/${id}`}>
       <a className="flex px-4 py-8 cursor-pointer justify-between">
         <div className="flex space-x-4">
-          <div className="w-20 h-20 bg-gray-400 rounded-md" />
+          {imageUrl ? (
+            <img
+              src={`https://res.cloudinary.com/dydish47p/image/upload/c_thumb,w_80,g_face/v1646826552/${imageUrl}`}
+              className="w-20 h-20 bg-gray-400 rounded-md"
+            />
+          ) : (
+            <div className="w-20 h-20 bg-gray-400 rounded-md" />
+          )}
           <div className="pt-2 flex flex-col">
             <h3 className="text-sm font-medium text-gray-900">{title}</h3>
             <span className="font-medium mt-1 text-gray-900">₩{price}</span>

--- a/libs/client/useImage.ts
+++ b/libs/client/useImage.ts
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+
+interface UseMutationState<T> {
+  loading: boolean;
+  data?: T;
+  error?: object;
+}
+
+const uploadPreset = 'dpsqflqu';
+const cloudName = 'dydish47p';
+
+export default function useImage<T = any>(): [(data: any) => void, UseMutationState<T>] {
+  const [state, setState] = useState<UseMutationState<T>>({
+    loading: false,
+    data: undefined,
+    error: undefined,
+  });
+
+  function mutation(file: File) {
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('upload_preset', uploadPreset);
+    setState((prev) => {
+      return { ...prev, loading: true };
+    });
+    fetch(`https://api.cloudinary.com/v1_1/${cloudName}/image/upload`, {
+      method: 'POST',
+      body: formData,
+    })
+      .then((response) => response.json().catch(() => {}))
+      .then((data) =>
+        setState((prev) => {
+          return { ...prev, data };
+        }),
+      )
+      .catch((error) =>
+        setState((prev) => {
+          return { ...prev, error };
+        }),
+      )
+      .finally(() =>
+        setState((prev) => {
+          return { ...prev, loading: false };
+        }),
+      );
+  }
+
+  return [mutation, state];
+}

--- a/pages/api/files.ts
+++ b/pages/api/files.ts
@@ -1,0 +1,23 @@
+import type { ResponseType } from '@customTypes/index';
+import { withApiSession, withHandler } from '@libs/server/index';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) {
+  // console.log(process.env.CLOUDINARY_UPLOAD_PRESET_NAME);
+  // console.log(process.env.CLOUDINARY_CLOUD_NAME);
+  // console.log(result);
+
+  console.log(req);
+
+  res.json({
+    ok: true,
+    url: '',
+  });
+}
+
+export default withApiSession(
+  withHandler({
+    methods: ['POST'],
+    handler,
+  }),
+);

--- a/pages/api/products/index.ts
+++ b/pages/api/products/index.ts
@@ -21,7 +21,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) 
       break;
     case 'POST':
       const {
-        body: { name, price, description },
+        body: { name, price, description, photoId },
         session: { user },
       } = req;
       const product = await client.product.create({
@@ -29,7 +29,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) 
           name,
           price: +price,
           description,
-          imageUrl: 'not implemented yet',
+          imageUrl: photoId ?? null,
           user: {
             connect: {
               id: user?.id,

--- a/pages/api/users/me/index.ts
+++ b/pages/api/users/me/index.ts
@@ -14,7 +14,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) 
       });
     case 'POST':
       const {
-        body: { email, phone, name },
+        body: { email, phone, name, avatarId },
         session: { user },
       } = req;
       const currentUser = await client.user.findUnique({
@@ -36,21 +36,16 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) 
             id: true,
           },
         });
-        if (isExists) {
-          return res.json({
-            ok: false,
-            error: 'Email already exists',
+        if (!isExists) {
+          await client.user.update({
+            where: {
+              id: user?.id,
+            },
+            data: {
+              email,
+            },
           });
         }
-        await client.user.update({
-          where: {
-            id: user?.id,
-          },
-          data: {
-            email,
-          },
-        });
-        return res.json({ ok: true });
       }
       if (phone && currentUser?.phone !== phone) {
         const isExists = await client.user.findFirst({
@@ -61,21 +56,16 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) 
             id: true,
           },
         });
-        if (isExists) {
-          return res.json({
-            ok: false,
-            error: 'Phone number in use',
+        if (!isExists) {
+          await client.user.update({
+            where: {
+              id: user?.id,
+            },
+            data: {
+              phone,
+            },
           });
         }
-        await client.user.update({
-          where: {
-            id: user?.id,
-          },
-          data: {
-            phone,
-          },
-        });
-        return res.json({ ok: true, message: 'not changed' });
       }
       if (name && currentUser?.name !== name) {
         await client.user.update({
@@ -86,7 +76,18 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) 
             name,
           },
         });
-        return res.json({ ok: true, message: 'not changed' });
+      }
+      if (avatarId) {
+        console.log(avatarId);
+        await client.user.update({
+          where: {
+            id: user?.id,
+          },
+          data: {
+            avatar: avatarId,
+          },
+        });
+        res.json({ ok: true });
       }
       return res.json({ ok: true });
     default:

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -25,6 +25,7 @@ const Home: NextPage = () => {
             title={product.name}
             price={product.price}
             hearts={product._count.favs}
+            imageUrl={product.imageUrl}
             comments={1}
           />
         ))}

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -1,10 +1,10 @@
 import { Product, User } from '.prisma/client';
 import { Button, Layout } from '@components/index';
-import { cls, useMutation, useUser } from '@libs/client';
+import { cls, useMutation } from '@libs/client';
 import type { NextPage } from 'next';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import useSWR, { useSWRConfig } from 'swr';
+import useSWR from 'swr';
 
 interface ProductWithUser extends Product {
   user: User;
@@ -37,9 +37,23 @@ const ItemDetail: NextPage = () => {
     <Layout canGoBack>
       <div className="px-4 py-10">
         <div className="mb-8">
-          <div className="h-96 bg-slate-300" />
-          <div className="flex cursor-pointer py-3 border-t border-b items-center space-x-3">
-            <div className="w-12 h-12 rounded-full bg-slate-300" />
+          {data?.product.imageUrl ? (
+            <img
+              src={`https://res.cloudinary.com/dydish47p/image/upload/v1646815874/${data.product.imageUrl}`}
+              className="mx-auto h-96 bg-slate-300"
+            />
+          ) : (
+            <div className="h-96 bg-slate-300" />
+          )}
+          <div className="flex cursor-pointer py-3 border-b items-center space-x-3">
+            {data?.product.user.avatar ? (
+              <img
+                src={`https://res.cloudinary.com/dydish47p/image/upload/v1646815874/${data.product.user.avatar}`}
+                className="w-12 h-12 rounded-full bg-slate-300"
+              />
+            ) : (
+              <div className="w-12 h-12 rounded-full bg-slate-300" />
+            )}
             <div>
               {data ? (
                 <>

--- a/pages/products/upload.tsx
+++ b/pages/products/upload.tsx
@@ -1,15 +1,16 @@
 import { Product } from '.prisma/client';
 import { Button, Input, Layout, TextArea } from '@components/index';
-import { useMutation } from '@libs/client/index';
+import { useMutation, useUser } from '@libs/client/index';
 import type { NextPage } from 'next';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 interface UploadProductForm {
   name: string;
   price: number;
   description: string;
+  photo: FileList;
 }
 
 interface UploadProductMutation {
@@ -19,16 +20,38 @@ interface UploadProductMutation {
 
 const Upload: NextPage = () => {
   const router = useRouter();
-  const { register, handleSubmit } = useForm<UploadProductForm>();
+  const { user } = useUser();
+  const { register, handleSubmit, watch } = useForm<UploadProductForm>();
   const [upload, { loading, data, error }] = useMutation<UploadProductMutation>('/api/products');
+  const [photoPreview, setPhotoPreview] = useState('');
+  const photo = watch('photo');
 
   useEffect(() => {
     if (data?.ok) router.replace(`/products/${data.product.id}`);
   }, [data, router]);
 
-  const onValid = (data: UploadProductForm) => {
-    if (loading) return;
-    console.log(data);
+  useEffect(() => {
+    if (photo && photo.length) {
+      const file = photo[0];
+      setPhotoPreview(URL.createObjectURL(file));
+    }
+  }, [photo]);
+
+  const onValid = async ({ name, price, description, photo }: UploadProductForm) => {
+    if (loading || !user) return;
+    if (photo && photo.length) {
+      const form = new FormData();
+      form.append('file', photo[0], name);
+      form.append('upload_preset', 'xp2um1vf');
+      const { public_id: photoId } = await (
+        await fetch('https://api.cloudinary.com/v1_1/dydish47p/image/upload', {
+          method: 'POST',
+          body: form,
+        })
+      ).json();
+      upload({ name, price, description, photoId });
+      return;
+    }
     upload(data);
   };
 
@@ -36,17 +59,21 @@ const Upload: NextPage = () => {
     <Layout canGoBack title="Upload Product">
       <form className="p-4 space-y-4" onSubmit={handleSubmit(onValid)}>
         <div>
-          <label className="w-full cursor-pointer text-gray-600 hover:border-orange-500 hover:text-orange-500 flex items-center justify-center border-2 border-dashed border-gray-300 h-48 rounded-md">
-            <svg className="h-12 w-12" stroke="currentColor" fill="none" viewBox="0 0 48 48" aria-hidden="true">
-              <path
-                d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02"
-                strokeWidth={2}
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-            <input className="hidden" type="file" />
-          </label>
+          {photoPreview ? (
+            <img src={`${photoPreview}`} className="mx-auto text-gray-600 h-48 rounded-md" />
+          ) : (
+            <label className="w-full cursor-pointer text-gray-600 hover:border-orange-500 hover:text-orange-500 flex items-center justify-center border-2 border-dashed border-gray-300 h-48 rounded-md">
+              <svg className="h-12 w-12" stroke="currentColor" fill="none" viewBox="0 0 48 48" aria-hidden="true">
+                <path
+                  d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02"
+                  strokeWidth={2}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+              <input {...register('photo')} accept="image/*" className="hidden" type="file" />
+            </label>
+          )}
         </div>
         <Input register={register('name', { required: true })} name="name" label="Name" type="text" required />
         <Input

--- a/pages/profile/edit.tsx
+++ b/pages/profile/edit.tsx
@@ -1,13 +1,15 @@
 import { Button, Input, Layout } from '@components/index';
 import { useMutation, useUser } from '@libs/client';
+import useImage from '@libs/client/useImage';
 import type { NextPage } from 'next';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 interface EditProfileForm {
   email?: string;
   phone?: string;
   name?: string;
+  avatar?: FileList;
   formErrors?: string;
 }
 
@@ -19,17 +21,27 @@ interface EditProfileResponse {
 const EditProfile: NextPage = () => {
   const { user } = useUser();
   const [editProfile, { loading, data }] = useMutation<EditProfileResponse>('/api/users/me');
+  const [changeAvatar, { loading: avatarLoading, data: avatarData }] = useImage();
   const {
     register,
     handleSubmit,
     setValue,
     setError,
     formState: { errors },
+    watch,
   } = useForm<EditProfileForm>();
-  const onValid = ({ email, phone, name }: EditProfileForm) => {
+  const [avatarPreview, setAvatarPreview] = useState('');
+  const avatar = watch('avatar');
+
+  const onValid = async ({ email, phone, name, avatar }: EditProfileForm) => {
     if (loading) return;
-    if (!email && !phone && !name)
+    if (!email && !phone && !name) {
       return setError('formErrors', { message: 'Email or Phone number is required. Choose one, not both.' });
+    }
+    if (avatar && avatar.length) {
+      const file = avatar[0];
+      changeAvatar(file);
+    }
     editProfile({ email, phone, name });
   };
 
@@ -38,23 +50,36 @@ const EditProfile: NextPage = () => {
     setValue('email', user?.email ?? '');
     setValue('phone', user?.phone ?? '');
   }, [user, setValue]);
+
   useEffect(() => {
     if (data && !data.ok) {
       setError('formErrors', { message: data?.error });
     }
   }, [data, setError]);
+  useEffect(() => {
+    if (avatar && avatar.length) {
+      const file = avatar[0];
+      setAvatarPreview(URL.createObjectURL(file));
+    }
+  }, [avatar]);
+
+  console.log(avatarData);
 
   return (
     <Layout title="Edit Profile" canGoBack>
       <form onSubmit={handleSubmit(onValid)} className="py-10 px-4 space-y-4">
         <div className="flex items-center space-x-3">
-          <div className="w-14 h-14 rounded-full bg-slate-500" />
+          {avatarPreview ? (
+            <img src={avatarPreview} className="w-14 h-14 rounded-full bg-slate-500" />
+          ) : (
+            <div className="w-14 h-14 rounded-full bg-slate-500" />
+          )}
           <label
             htmlFor="picture"
             className="cursor-pointer py-2 px-3 border hover:bg-gray-50 border-gray-300 rounded-md shadow-sm text-sm font-medium focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 text-gray-700"
           >
             Change
-            <input id="picture" type="file" className="hidden" accept="image/*" />
+            <input {...register('avatar')} id="picture" type="file" className="hidden" accept="image/*" />
           </label>
         </div>
         <Input register={register('name', { required: true })} name="Name" label="name" type="text" required={true} />

--- a/pages/profile/edit.tsx
+++ b/pages/profile/edit.tsx
@@ -34,7 +34,7 @@ const EditProfile: NextPage = () => {
   const onValid = async ({ email, phone, name, avatar }: EditProfileForm) => {
     if (loading) return;
     if (!email && !phone && !name) {
-      return setError('formErrors', { message: 'Email or Phone number is required. Choose one, not both.' });
+      return setError('formErrors', { message: 'Email or Phone number is required' });
     }
     if (avatar && avatar.length && user) {
       const form = new FormData();

--- a/pages/profile/index.tsx
+++ b/pages/profile/index.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import useSWR from 'swr';
 
 interface ReviewWithUser extends Review {
-  createdBy: User;
+  createdBy: Pick<User, 'id' | 'name' | 'avatar'>;
 }
 
 interface ReviewsResponse {
@@ -107,7 +107,14 @@ const Profile: NextPage = () => {
           return (
             <div key={review.id} className="mt-12">
               <div className="flex space-x-4 items-center">
-                <div className="w-12 h-12 rounded-full bg-slate-500" />
+                {review.createdBy.avatar ? (
+                  <img
+                    src={`https://res.cloudinary.com/dydish47p/image/upload/v1646815874/${review.createdBy.avatar}`}
+                    className="w-12 h-12 rounded-full bg-slate-500"
+                  />
+                ) : (
+                  <div className="w-12 h-12 rounded-full bg-slate-500" />
+                )}
                 <div>
                   <h4 className="text-sm font-bold text-gray-800">{review.createdBy.name}</h4>
                   <div className="flex items-center">

--- a/pages/profile/index.tsx
+++ b/pages/profile/index.tsx
@@ -17,11 +17,19 @@ interface ReviewsResponse {
 const Profile: NextPage = () => {
   const { user, isLoading } = useUser();
   const { data } = useSWR<ReviewsResponse>('/api/reviews');
+
   return (
     <Layout hasTabBar title="나의 캐럿">
       <div className="px-4">
         <div className="flex items-center mt-4 space-x-3">
-          <div className="w-16 h-16 bg-slate-500 rounded-full" />
+          {user?.avatar ? (
+            <img
+              src={`https://res.cloudinary.com/dydish47p/image/upload/v1646815874/${user?.avatar}`}
+              className="w-16 h-16 bg-slate-500 rounded-full"
+            />
+          ) : (
+            <div className="w-16 h-16 bg-slate-500 rounded-full" />
+          )}
           <div className="flex flex-col">
             <span className="font-medium text-gray-900">{isLoading ? 'Loading' : user?.name}</span>
             <Link href="/profile/edit">
@@ -95,6 +103,7 @@ const Profile: NextPage = () => {
           </Link>
         </div>
         {data?.reviews.map((review) => {
+          console.log(review);
           return (
             <div key={review.id} className="mt-12">
               <div className="flex space-x-4 items-center">


### PR DESCRIPTION
## 커밋 내용 요약

- cloudinary를 통한 이미지 업로드
- 등록된 이미지 보이기
  - product detail
  - product list(home)
  - profile
  - chat(comment)

## 구현방법 및 변경사항

- 유료 서비스인 cloudflare 대신 기존에 사용하던 무료 서비스 cloudinary를 사용
  - DCU가 아닌 API 요청임으로 구현 방식에 차이가 있음
- useMutation 대신 이미지 업로드 시 사용할 커스텀 훅을 추가
  - cloudinary에 다이렉트로 이미지를 추가하나, 노출되는 정보가 있음

## 질문사항

- cloudinary 사용에 필요한 프리셋명과 클라우드명을 사용자에게 보이지 않는 방법이 있을까
  - env 파일의 변수를 프론트엔드에서 받아올 수 없기 때문에 undefined가 호출됨