### PR TITLE
refactor(nextjs image): replace img tag with Image component

### DIFF
--- a/components/item.tsx
+++ b/components/item.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import Link from 'next/link';
 
 interface ItemProps {
@@ -15,9 +16,12 @@ export default function Item({ title, id, price, hearts, imageUrl, comments }: I
       <a className="flex px-4 py-8 cursor-pointer justify-between">
         <div className="flex space-x-4">
           {imageUrl ? (
-            <img
-              src={`https://res.cloudinary.com/dydish47p/image/upload/c_thumb,w_80,g_face/v1646826552/${imageUrl}`}
-              className="w-20 h-20 bg-gray-400 rounded-md"
+            <Image
+              src={`https://res.cloudinary.com/dydish47p/image/upload/c_thumb,w_80,h_80/v1646886648/${imageUrl}`}
+              className="rounded-md -z-10"
+              height={80}
+              width={80}
+              alt="product thumbnail"
             />
           ) : (
             <div className="w-20 h-20 bg-gray-400 rounded-md" />

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -14,7 +14,7 @@ export default function Message({ message, avatarUrl, reversed }: MessageProps) 
       {avatarUrl ? (
         <Image
           src={`https://res.cloudinary.com/dydish47p/image/upload/c_thumb,w_32,h_32,g_face/v1646886648/${avatarUrl}`}
-          className="rounded-full bg-slate-400"
+          className="rounded-full bg-slate-400 -z-10"
           width={32}
           height={32}
           alt="message avatar"

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -1,15 +1,27 @@
 import { cls } from '@libs/client/utils';
+import Image from 'next/image';
 
 interface MessageProps {
   message: string;
   reversed?: boolean;
-  avatarUrl?: string;
+  avatarUrl?: string | null;
 }
 
 export default function Message({ message, avatarUrl, reversed }: MessageProps) {
+  console.log(avatarUrl);
   return (
     <div className={cls('flex items-start space-x-2', reversed ? 'flex-row-reverse space-x-reverse' : '')}>
-      <div className="w-8 h-8 rounded-full bg-slate-400" />
+      {avatarUrl ? (
+        <Image
+          src={`https://res.cloudinary.com/dydish47p/image/upload/c_thumb,w_32,h_32,g_face/v1646886648/${avatarUrl}`}
+          className="rounded-full bg-slate-400"
+          width={32}
+          height={32}
+          alt="message avatar"
+        />
+      ) : (
+        <div className="w-8 h-8 rounded-full bg-slate-400" />
+      )}
       <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
         <p>{message}</p>
       </div>

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+  images: {
+    domains: ['res.cloudinary.com'],
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/pages/api/posts/[id]/index.ts
+++ b/pages/api/posts/[id]/index.ts
@@ -26,8 +26,8 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) 
                 },
               },
             },
-            take: 10,
-            skip: 20,
+            // take: 10,
+            // skip: 20,
           },
           _count: {
             select: {

--- a/pages/community/[id].tsx
+++ b/pages/community/[id].tsx
@@ -2,6 +2,7 @@ import { Answer, Post, User } from '.prisma/client';
 import { Layout, TextArea } from '@components/index';
 import { cls, useMutation } from '@libs/client';
 import type { NextPage } from 'next';
+import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
@@ -79,6 +80,8 @@ const CommunityPostDetail: NextPage = () => {
     }
   }, [answerData, reset, mutate]);
 
+  console.log(data);
+
   return (
     <Layout canGoBack>
       <div>
@@ -86,7 +89,17 @@ const CommunityPostDetail: NextPage = () => {
           동네질문
         </span>
         <div className="flex mb-3 px-4 cursor-pointer pb-3 items-center space-x-3">
-          <div className="w-10 h-10 rounded-full bg-slate-300" />
+          {data?.post?.user.avatar ? (
+            <Image
+              src={`https://res.cloudinary.com/dydish47p/image/upload/c_thumb,w_40,h_40/v1646886648/${data.post.user.avatar}`}
+              className="rounded-full"
+              width={40}
+              height={40}
+              alt="writer avatar"
+            />
+          ) : (
+            <div className="w-10 h-10 rounded-full bg-slate-300" />
+          )}
           <div>
             <p className="text-sm font-medium text-gray-700">{data ? `${data.post?.user.name}` : 'Loading'}</p>
             <Link href={`/users/profiles/${data?.post?.user.id}`}>
@@ -143,7 +156,17 @@ const CommunityPostDetail: NextPage = () => {
           {data?.post?.answers.map((answer) => {
             return (
               <div key={answer.id} className="flex items-start space-x-3">
-                <div className="w-8 h-8 bg-slate-200 rounded-full" />
+                {answer.user.avatar ? (
+                  <Image
+                    src={`https://res.cloudinary.com/dydish47p/image/upload/c_thumb,w_32,h_32/v1646886648/${answer.user.avatar}`}
+                    className="bg-slate-200 rounded-full"
+                    width={32}
+                    height={32}
+                    alt="comment avatar"
+                  />
+                ) : (
+                  <div className="w-8 h-8 bg-slate-200 rounded-full" />
+                )}
                 <div>
                   <span className="text-sm block font-medium text-gray-700">{answer.user.name}</span>
                   <span className="text-xs text-gray-500 block ">{answer.createdAt}</span>

--- a/pages/community/[id].tsx
+++ b/pages/community/[id].tsx
@@ -92,7 +92,7 @@ const CommunityPostDetail: NextPage = () => {
           {data?.post?.user.avatar ? (
             <Image
               src={`https://res.cloudinary.com/dydish47p/image/upload/c_thumb,w_40,h_40/v1646886648/${data.post.user.avatar}`}
-              className="rounded-full"
+              className="rounded-full -z-10"
               width={40}
               height={40}
               alt="writer avatar"
@@ -159,7 +159,7 @@ const CommunityPostDetail: NextPage = () => {
                 {answer.user.avatar ? (
                   <Image
                     src={`https://res.cloudinary.com/dydish47p/image/upload/c_thumb,w_32,h_32/v1646886648/${answer.user.avatar}`}
-                    className="bg-slate-200 rounded-full"
+                    className="bg-slate-200 rounded-full -z-10"
                     width={32}
                     height={32}
                     alt="comment avatar"

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -2,6 +2,7 @@ import { Product, User } from '.prisma/client';
 import { Button, Layout } from '@components/index';
 import { cls, useMutation } from '@libs/client';
 import type { NextPage } from 'next';
+import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import useSWR from 'swr';
@@ -37,19 +38,22 @@ const ItemDetail: NextPage = () => {
     <Layout canGoBack>
       <div className="px-4 py-10">
         <div className="mb-8">
-          {data?.product.imageUrl ? (
-            <img
-              src={`https://res.cloudinary.com/dydish47p/image/upload/v1646815874/${data.product.imageUrl}`}
-              className="mx-auto h-96 bg-slate-300"
+          <div className="relative pb-80">
+            <Image
+              src={`https://res.cloudinary.com/dydish47p/image/upload/v1646886648/${data?.product.imageUrl}`}
+              className="object-contain -z-10"
+              layout="fill"
+              alt="product photo"
             />
-          ) : (
-            <div className="h-96 bg-slate-300" />
-          )}
+          </div>
           <div className="flex cursor-pointer py-3 border-b items-center space-x-3">
             {data?.product.user.avatar ? (
-              <img
+              <Image
                 src={`https://res.cloudinary.com/dydish47p/image/upload/v1646815874/${data.product.user.avatar}`}
-                className="w-12 h-12 rounded-full bg-slate-300"
+                className="w-12 h-12 rounded-full bg-slate-300 -z-10"
+                width={48}
+                height={48}
+                alt="user avatar"
               />
             ) : (
               <div className="w-12 h-12 rounded-full bg-slate-300" />

--- a/pages/products/upload.tsx
+++ b/pages/products/upload.tsx
@@ -2,6 +2,7 @@ import { Product } from '.prisma/client';
 import { Button, Input, Layout, TextArea } from '@components/index';
 import { useMutation, useUser } from '@libs/client/index';
 import type { NextPage } from 'next';
+import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -59,10 +60,17 @@ const Upload: NextPage = () => {
     <Layout canGoBack title="Upload Product">
       <form className="p-4 space-y-4" onSubmit={handleSubmit(onValid)}>
         <div>
-          {photoPreview ? (
-            <img src={`${photoPreview}`} className="mx-auto text-gray-600 h-48 rounded-md" />
-          ) : (
-            <label className="w-full cursor-pointer text-gray-600 hover:border-orange-500 hover:text-orange-500 flex items-center justify-center border-2 border-dashed border-gray-300 h-48 rounded-md">
+          <label className="w-full cursor-pointer text-gray-600 hover:border-orange-500 hover:text-orange-500 flex items-center justify-center border-2 border-dashed border-gray-300 h-48 rounded-md">
+            {photoPreview ? (
+              <div className="relative py-24 px-60">
+                <Image
+                  src={photoPreview}
+                  className="rounded-md object-contain -z-10"
+                  layout="fill"
+                  alt="product preview image"
+                />
+              </div>
+            ) : (
               <svg className="h-12 w-12" stroke="currentColor" fill="none" viewBox="0 0 48 48" aria-hidden="true">
                 <path
                   d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02"
@@ -71,9 +79,9 @@ const Upload: NextPage = () => {
                   strokeLinejoin="round"
                 />
               </svg>
-              <input {...register('photo')} accept="image/*" className="hidden" type="file" />
-            </label>
-          )}
+            )}
+            <input {...register('photo')} accept="image/*" className="hidden" type="file" />
+          </label>
         </div>
         <Input register={register('name', { required: true })} name="name" label="Name" type="text" required />
         <Input

--- a/pages/streams/[id].tsx
+++ b/pages/streams/[id].tsx
@@ -65,7 +65,14 @@ const Stream: NextPage = () => {
           <h2 className="text-2xl font-bold text-gray-900">Live Chat</h2>
           <div className="py-10 pb-16 h-[50vh] overflow-y-scroll  px-4 space-y-4">
             {data?.stream?.messages.map((message) => {
-              return <Chat key={message.id} message={message.message} reversed={user?.id === message.user.id} />;
+              return (
+                <Chat
+                  key={message.id}
+                  message={message.message}
+                  avatarUrl={message.user.avatar}
+                  reversed={user?.id === message.user.id}
+                />
+              );
             })}
           </div>
           <div className="fixed py-2 bg-white bottom-0 inset-x-0">


### PR DESCRIPTION
## 커밋 내용 요약

- <img> 태그를 Nextjs에서 지원하는 Image 컴포넌트로 대체

## 코드 변경 이유

- 페이지 성능 향상
- 사용자 경험 개선

## 구현방법 및 변경사항

- img 태그를 Nextjs의 Image 컴포넌트로 대체

## 질문사항

- Image 태그 사용 시 헤더를 커버하는 현상 해결방법
  - 지금은 -z-10으로 해결(z-index: -10)