### PR TITLE
feat(chat): API 기능 변경, (유사) 실시간 채팅 기능 추가

### DIFF
--- a/components/message.tsx
+++ b/components/message.tsx
@@ -22,7 +22,7 @@ export default function Message({ message, avatarUrl, reversed }: MessageProps) 
         <div className="w-8 h-8 rounded-full bg-slate-400" />
       )}
       <div className="w-1/2 text-sm text-gray-700 p-2 border border-gray-300 rounded-md">
-        <p>{message}</p>
+        <p className="break-words">{message}</p>
       </div>
     </div>
   );

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -8,7 +8,6 @@ interface MessageProps {
 }
 
 export default function Message({ message, avatarUrl, reversed }: MessageProps) {
-  console.log(avatarUrl);
   return (
     <div className={cls('flex items-start space-x-2', reversed ? 'flex-row-reverse space-x-reverse' : '')}>
       {avatarUrl ? (

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,7 +9,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         fetcher: (url: string) => fetch(url).then((response) => response.json()),
       }}
     >
-      <div className="w-full max-w-xl mx-auto">
+      <div className="w-full max-w-xl mx-auto overflow-x-auto">
         <Component {...pageProps} />
       </div>
     </SWRConfig>

--- a/pages/api/chats/[id]/index.ts
+++ b/pages/api/chats/[id]/index.ts
@@ -15,19 +15,44 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) 
         },
         select: {
           id: true,
-          buyerId: true,
+          buyer: {
+            select: {
+              id: true,
+              avatar: true,
+              name: true,
+            },
+          },
           product: {
             select: {
               id: true,
               name: true,
-              userId: true,
               state: true,
+              user: {
+                select: {
+                  id: true,
+                  avatar: true,
+                  name: true,
+                },
+              },
             },
           },
-          messages: true,
+          messages: {
+            select: {
+              id: true,
+              message: true,
+              chatRoomId: true,
+              user: {
+                select: {
+                  id: true,
+                  name: true,
+                  avatar: true,
+                },
+              },
+            },
+          },
         },
       });
-      if (chatRoom && chatRoom.buyerId !== user?.id && chatRoom.product.userId !== user?.id) {
+      if (chatRoom && chatRoom.buyer.id !== user?.id && chatRoom.product.user.id !== user?.id) {
         return res.json({
           ok: false,
           message: 'only buyer and seller can join chatRoom',

--- a/pages/api/chats/index.ts
+++ b/pages/api/chats/index.ts
@@ -1,0 +1,75 @@
+import type { ResponseType } from '@customTypes/index';
+import { client, withApiSession, withHandler } from '@libs/server/index';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) {
+  switch (req.method) {
+    case 'GET':
+      const {
+        session: { user },
+      } = req;
+      if (!user || !user.id) {
+        return res.json({
+          ok: false,
+          message: 'cannot get user data',
+        });
+      }
+      const chatRooms = await client.chatRoom.findMany({
+        where: {
+          OR: [
+            {
+              product: {
+                userId: user.id,
+              },
+            },
+            {
+              buyerId: user.id,
+            },
+          ],
+        },
+        select: {
+          id: true,
+          buyer: {
+            select: {
+              id: true,
+              name: true,
+              avatar: true,
+            },
+          },
+          product: {
+            select: {
+              user: {
+                select: {
+                  id: true,
+                  name: true,
+                  avatar: true,
+                },
+              },
+            },
+          },
+          messages: {
+            orderBy: {
+              createdAt: 'desc',
+            },
+            take: 1,
+          },
+        },
+      });
+      return res.json({
+        ok: true,
+        chatRooms,
+      });
+    default:
+      return res.json({
+        ok: false,
+        message: `${req.method} is not allowed`,
+      });
+  }
+}
+
+export default withApiSession(
+  withHandler({
+    methods: ['GET'],
+    handler,
+  }),
+);

--- a/pages/chats/index.tsx
+++ b/pages/chats/index.tsx
@@ -25,27 +25,26 @@ interface ChatRoomResult {
 const Chats: NextPage = () => {
   const { user, isLoading } = useUser();
   const { data, error } = useSWR<ChatRoomResult>(user?.id ? `/api/chats` : null);
-  console.log(data);
   return (
     <Layout hasTabBar title="채팅">
       <div className="divide-y-[1px] ">
         {data?.chatRooms.map((chatRoom) => {
           const opponent: UserInfo = chatRoom.buyer.id !== user?.id ? chatRoom.buyer : chatRoom.product.user;
-          console.log(opponent);
-          console.log(chatRoom.messages[0]);
           return (
             <Link href={`/chats/${chatRoom.id}`} key={chatRoom.id}>
               <a className="flex px-4 cursor-pointer py-3 items-center space-x-3">
-                <Image
-                  src={`https://res.cloudinary.com/dydish47p/image/upload/c_thumb,w_48,h_48,g_face/v1646978352/${opponent.avatar}`}
-                  className="w-12 h-12 rounded-full bg-slate-300"
-                  width={48}
-                  height={48}
-                  alt="opponent avatar"
-                />
-                <div>
+                <div className="flex-shrink-0">
+                  <Image
+                    src={`https://res.cloudinary.com/dydish47p/image/upload/c_thumb,w_48,h_48,g_face/v1646978352/${opponent.avatar}`}
+                    className="w-12 h-12 rounded-full bg-slate-300"
+                    width={48}
+                    height={48}
+                    alt="opponent avatar"
+                  />
+                </div>
+                <div className="overflow-x-hidden">
                   <p className="text-gray-700">{opponent.name}</p>
-                  <p className="text-sm  text-gray-500">
+                  <p className="inline-block text-sm text-gray-500">
                     {chatRoom.messages[0] ? chatRoom.messages[0].message : '나눈 대화가 없습니다'}
                   </p>
                 </div>

--- a/pages/chats/index.tsx
+++ b/pages/chats/index.tsx
@@ -1,12 +1,12 @@
-import type { NextPage } from "next";
-import Link from "next/link";
-import { Layout } from "@components/index";
-import useSWR from "swr";
-import { useUser } from "@libs/client";
-import { Message, User } from "@prisma/client";
-import Image from "next/image";
+import type { NextPage } from 'next';
+import Link from 'next/link';
+import { Layout } from '@components/index';
+import useSWR from 'swr';
+import { useUser } from '@libs/client';
+import { Message, User } from '@prisma/client';
+import Image from 'next/image';
 
-type UserInfo = Pick<User, "id" | "name" | "avatar">;
+type UserInfo = Pick<User, 'id' | 'name' | 'avatar'>;
 
 interface ChatRoom {
   id: number;
@@ -24,18 +24,15 @@ interface ChatRoomResult {
 
 const Chats: NextPage = () => {
   const { user, isLoading } = useUser();
-  const { data, error } = useSWR<ChatRoomResult>(
-    user?.id ? `/api/chats/${user.id}` : null
-  );
+  const { data, error } = useSWR<ChatRoomResult>(user?.id ? `/api/chats` : null);
   console.log(data);
   return (
     <Layout hasTabBar title="채팅">
       <div className="divide-y-[1px] ">
         {data?.chatRooms.map((chatRoom) => {
-          const opponent: UserInfo =
-            chatRoom.buyer.id !== user?.id
-              ? chatRoom.buyer
-              : chatRoom.product.user;
+          const opponent: UserInfo = chatRoom.buyer.id !== user?.id ? chatRoom.buyer : chatRoom.product.user;
+          console.log(opponent);
+          console.log(chatRoom.messages[0]);
           return (
             <Link href={`/chats/${chatRoom.id}`} key={chatRoom.id}>
               <a className="flex px-4 cursor-pointer py-3 items-center space-x-3">
@@ -49,7 +46,7 @@ const Chats: NextPage = () => {
                 <div>
                   <p className="text-gray-700">{opponent.name}</p>
                   <p className="text-sm  text-gray-500">
-                    {chatRoom.messages[0] ?? "나눈 대화가 없습니다"}
+                    {chatRoom.messages[0] ? chatRoom.messages[0].message : '나눈 대화가 없습니다'}
                   </p>
                 </div>
               </a>


### PR DESCRIPTION
## 커밋 내용 요약

- API 구조 & 데이터 변경
- (유사) 실시간 채팅 기능 추가

## 코드 변경 이유

- API
  - userId 대신 번호, 이름, 아바타 URL을 포함하도록 변경
  - userId를 query 대신 session으로 받아오도록 변경
    - chats/[id] : 사용자 별 채팅 조회 => 채팅방
    - chats/ index : 사용자 별 채팅 조회

## 구현방법 및 변경사항

- 기존 목적을 구현한 방법
- 기존 목적에서 변경된 내용

## 리뷰 중점 사항

- 채팅을 사용하는 다른 페이지에서 자동 스크롤 기능 추가
  - 채팅방에서 구현해놓은 기능 참고하기

## 질문사항

- text overflow 다른 사람은 어떻게 처리하지?
