### PR TITLE
fix(reserve): 물품 상태 갱신 시 알맞은 물품의 상태가 갱신되도록 버그 수정

### DIFF
--- a/components/button-item.tsx
+++ b/components/button-item.tsx
@@ -1,4 +1,4 @@
-import { Product, ProductState } from '.prisma/client';
+import { ProductState } from '.prisma/client';
 import { useMutation, useUser } from '@libs/client';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -74,7 +74,7 @@ export default function ButtonItem({ title, id, price, hearts, imageUrl, state, 
         {state === 'onList' && (
           <button
             onClick={() => onSetBookedClick('booked')}
-            className="cursor-pointer w-full hover:bg-orange-500 hover:text-white active:bg-orange-600 active:text-white first:rounded-l-md last:rounded-r-md"
+            className="cursor-pointer w-full hover:bg-orange-500 hover:text-white active:bg-orange-600 active:text-white first:rounded-l-md last:rounded-r-md active:hover:bg-orange-600 focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 focus:outline-none focus:border-none"
           >
             {loading ? 'Loading...' : '예약중으로 변경하기'}
           </button>
@@ -82,14 +82,14 @@ export default function ButtonItem({ title, id, price, hearts, imageUrl, state, 
         {state === 'booked' && (
           <button
             onClick={() => onSetProductStateClick('onList')}
-            className="cursor-pointer w-full hover:bg-orange-500 hover:text-white active:bg-orange-600 active:text-white first:rounded-l-md last:rounded-r-md"
+            className="cursor-pointer w-full hover:bg-orange-500 hover:text-white active:bg-orange-600 active:text-white first:rounded-l-md last:rounded-r-md active:hover:bg-orange-600 focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 focus:outline-none focus:border-none"
           >
             {loading ? 'Loading...' : '판매중으로 변경하기'}
           </button>
         )}
         <button
           onClick={() => onSetProductStateClick('sold')}
-          className="cursor-pointer w-full hover:bg-orange-500 hover:text-white active:bg-orange-600 active:text-white first:rounded-l-md last:rounded-r-md"
+          className="cursor-pointer w-full hover:bg-orange-500 hover:text-white active:bg-orange-600 active:text-white first:rounded-l-md last:rounded-r-md active:hover:bg-orange-600 focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 focus:outline-none focus:border-none"
         >
           {loading ? 'Loading...' : '거래완료로 변경하기'}
         </button>

--- a/components/product-list.tsx
+++ b/components/product-list.tsx
@@ -1,8 +1,6 @@
 import { Product, ProductState } from '.prisma/client';
 import { Item } from '@components/index';
 import { ProductWithCount } from '@customTypes/index';
-import { useMutation, useUser } from '@libs/client';
-import { useEffect } from 'react';
 import useSWR from 'swr';
 import ButtonItem from './button-item';
 
@@ -41,7 +39,7 @@ export default function ProductList({ kind }: ProductListProps) {
             return (
               <ButtonItem
                 key={record.id}
-                id={record.id}
+                id={record.product.id}
                 title={`[${productStatehandler(record.product.state, kind)}]` + record.product.name}
                 price={record.product.price}
                 hearts={record.product._count.favs}
@@ -55,7 +53,7 @@ export default function ProductList({ kind }: ProductListProps) {
             return (
               <Item
                 key={record.id}
-                id={record.id}
+                id={record.product.id}
                 title={`[${productStatehandler(record.product.state, kind)}]` + record.product.name}
                 price={record.product.price}
                 hearts={record.product._count.favs}


### PR DESCRIPTION
## 커밋 내용 요약

- 물품 상태 변경 시 다른 물품의 상태가 변경되는 버그 수정

## 코드 변경 이유

- 기존 url query의 id는 판매목록 기준
- query의 id를 모두 판매목록 기준으로 변경
  - DB 요청 감소
  - 혼동 위험성 감소