### PR TITLE
fix(api): 동네생활 게시글 요청 api 메서드 변경

### DIFF
--- a/pages/api/posts/[id]/index.ts
+++ b/pages/api/posts/[id]/index.ts
@@ -1,13 +1,10 @@
-import type { ResponseType } from "@customTypes/index";
-import { client, withApiSession, withHandler } from "@libs/server/index";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { ResponseType } from '@customTypes/index';
+import { client, withApiSession, withHandler } from '@libs/server/index';
+import { NextApiRequest, NextApiResponse } from 'next';
 
-async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<ResponseType>
-) {
+async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) {
   switch (req.method) {
-    case "POST":
+    case 'GET':
       const {
         query: { id },
         session: { user },
@@ -56,7 +53,7 @@ async function handler(
           select: {
             id: true,
           },
-        })
+        }),
       );
       res.json({
         ok: true,
@@ -64,20 +61,20 @@ async function handler(
         isWondered,
       });
       break;
-    case "POST":
-    case "PUT":
-    case "DELETE":
+    case 'POST':
+    case 'PUT':
+    case 'DELETE':
     default:
       res.json({
         ok: false,
-        message: "Method not allowed",
+        message: 'Method not allowed',
       });
   }
 }
 
 export default withApiSession(
   withHandler({
-    methods: ["POST"],
+    methods: ['GET'],
     handler,
-  })
+  }),
 );


### PR DESCRIPTION
## 커밋 내용 요약

- 동네생활의 특정 게시물 데이터 요청 api 메서드를 POST에서 GET으로 변경

## 코드 변경 이유

- 데이텨 요청 시 GET메서드를 사용하나, POST로 설정되어 있었음
  - 405에러 발생